### PR TITLE
Add custom layer title capability

### DIFF
--- a/src/main/js/bundles/dn_relatedtables/PopupDefinition.js
+++ b/src/main/js/bundles/dn_relatedtables/PopupDefinition.js
@@ -13,7 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import moment from "esri/moment";
+import moment from "moment";
+
+function buildTitle(layer) {
+    const preconfiguredTitle = layer.popupTemplate?.title;
+    if (preconfiguredTitle) {
+        return preconfiguredTitle;
+    }
+    const titleFromDefaultPopup = layer.defaultPopupTemplate?.title;
+    if (titleFromDefaultPopup) {
+        return titleFromDefaultPopup;
+    }
+}
 
 export default class CustomPopupDefinition {
 
@@ -36,10 +47,11 @@ export default class CustomPopupDefinition {
                 const fields = metadata.fields;
                 const fieldNames = fields.map(f => f.name);
                 let displayField = metadata.displayField;
+                const preconfiguredTitle = buildTitle(layerOrSublayer)
                 let objectIdField = this._getObjectIdField(metadata.fields).name;
                 return {
                     fields: fieldNames,
-                    title: "{" + displayField + "}",
+                    title: preconfiguredTitle || "{" + displayField + "}",
                     content({graphic}) {
                         if (fields) {
                             /*let widget = layerOrSublayer._$popup_widget;


### PR DESCRIPTION
I copied over some code from the "popups-default" bundle that allows the configuration of custom titles.
**example**:
                          `{
                                "id": 32,
                                "title": "Forstflächen-Attributdaten",
                                "visible": true,
                                "popupTemplate": {
                                    "popupType": "related-tables-popup",
                                    "title": "Info über Forstfläche {FO_IDFBBCHR}"
                                }
                            }`